### PR TITLE
Add reader mode to passage endpoint for Bible reader

### DIFF
--- a/backend/src/main/java/org/biblememory/controller/PassageController.java
+++ b/backend/src/main/java/org/biblememory/controller/PassageController.java
@@ -19,12 +19,14 @@ public class PassageController {
     }
 
     @GetMapping
-    public ResponseEntity<?> getPassage(@RequestParam String q) {
+    public ResponseEntity<?> getPassage(
+            @RequestParam String q,
+            @RequestParam(required = false, defaultValue = "false") boolean reader) {
         if (q == null || q.isBlank()) {
             return ResponseEntity.badRequest()
                     .body(new org.biblememory.model.ApiError("VALIDATION_ERROR", "Query parameter 'q' is required"));
         }
-        EsvResult result = esvService.fetchPassage(q);
+        EsvResult result = esvService.fetchPassage(q, reader);
         if (!result.success()) {
             return ResponseEntity.badRequest()
                     .body(new org.biblememory.model.ApiError("ESV_ERROR", result.error()));

--- a/backend/src/main/java/org/biblememory/esv/EsvPassageService.java
+++ b/backend/src/main/java/org/biblememory/esv/EsvPassageService.java
@@ -23,6 +23,10 @@ public class EsvPassageService {
     }
 
     public EsvResult fetchPassage(String query) {
+        return fetchPassage(query, false);
+    }
+
+    public EsvResult fetchPassage(String query, boolean readerMode) {
         if (apiKey == null || apiKey.isBlank()) {
             return EsvResult.error("ESV API key not configured");
         }
@@ -31,8 +35,8 @@ public class EsvPassageService {
         }
         String encoded = URLEncoder.encode(query.trim(), StandardCharsets.UTF_8);
         String url = ESV_BASE + "?q=" + encoded
-                + "&include-passage-references=false"
-                + "&include-verse-numbers=false"
+                + "&include-passage-references=" + readerMode
+                + "&include-verse-numbers=" + readerMode
                 + "&include-footnotes=false"
                 + "&include-footnote-body=false"
                 + "&include-headings=false"
@@ -52,7 +56,7 @@ public class EsvPassageService {
                 String raw = passages != null && passages.length > 0
                         ? String.join("\n", passages).trim()
                         : "";
-                String text = sanitizePassageText(raw);
+                String text = sanitizePassageText(raw, readerMode);
                 return EsvResult.success(text, query);
             }
             return EsvResult.error("Failed to fetch passage");
@@ -62,9 +66,9 @@ public class EsvPassageService {
     }
 
     /**
-     * Sanitize ESV passage text: remove verse numbers, footnotes, headings, and extra formatting.
+     * Sanitize ESV passage text: remove verse numbers (unless reader mode), footnotes, headings, and extra formatting.
      */
-    private String sanitizePassageText(String text) {
+    private String sanitizePassageText(String text, boolean readerMode) {
         if (text == null || text.isBlank()) return "";
         // Remove "Footnotes" section and everything after it
         int footnotesIdx = text.toLowerCase().indexOf("footnotes");
@@ -73,8 +77,10 @@ public class EsvPassageService {
         }
         // Remove footnote references like (1), (2) in the text
         text = text.replaceAll("\\(\\d+\\)", "");
-        // Remove verse numbers in brackets like [16], [35]
-        text = text.replaceAll("\\s*\\[\\d+\\]\\s*", " ");
+        // Remove verse numbers in brackets like [16], [35] (skip in reader mode to keep verse markers)
+        if (!readerMode) {
+            text = text.replaceAll("\\s*\\[\\d+\\]\\s*", " ");
+        }
         // Remove trailing (ESV) copyright
         text = text.replaceAll("\\s*\\(ESV\\)\\s*$", "");
         // Remove section headings like "For God So Loved the World| " at start (phrase ending with |)


### PR DESCRIPTION
## Summary
Adds an optional `reader` query parameter to the passage API so the Bible reader can request verse-numbered text from the ESV API.

## Changes

### EsvPassageService.java
- Added overload: `fetchPassage(String query, boolean readerMode)`
- When `readerMode=true`:
  - Uses `include-verse-numbers=true` and `include-passage-references=true` in the ESV API URL
  - Skips verse-number stripping in `sanitizePassageText` (keeps `[n]` verse markers)
- When `readerMode=false` (default): keeps current behavior for CollectionDetail

### PassageController.java
- Added optional query param: `@RequestParam(required = false, defaultValue = "false") boolean reader`
- Passes `reader` to `esvService.fetchPassage(q, reader)`

## Usage
- **Default:** `GET /api/passages?q=John+3:16` — plain text, no verse numbers
- **Reader mode:** `GET /api/passages?q=John+3:16&reader=true` — verse-numbered text with passage references

Closes #3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional query parameter and threads it through to ESV request/sanitization; default behavior remains unchanged.
> 
> **Overview**
> Adds an optional `reader` query parameter to `GET /api/passages` and passes it through to `EsvPassageService`.
> 
> When `reader=true`, the ESV request now includes passage references and verse numbers, and sanitization preserves bracketed verse markers; when omitted/false, the endpoint keeps returning the prior plain text output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0003eda3179b97151cd82f908401120bc8aa819. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->