### PR TITLE
Fix #38: Verse restart on note save and correct chars turning incorrect

### DIFF
--- a/frontend/src/app/context/DataContext.tsx
+++ b/frontend/src/app/context/DataContext.tsx
@@ -284,11 +284,11 @@ export function DataProvider({ children }: { children: ReactNode }) {
     setVerses((prev) => prev.filter((v) => v.collectionId !== collectionId));
   };
 
-  const getVersesByCollection = (collectionId: string): Verse[] => {
+  const getVersesByCollection = useCallback((collectionId: string): Verse[] => {
     return verses
       .filter((v) => v.collectionId === collectionId)
       .sort((a, b) => a.order - b.order);
-  };
+  }, [verses]);
 
   const addVerse = async (collectionId: string, reference: string, text: string, source?: string) => {
     if (!user) return;

--- a/frontend/src/app/pages/TypingPractice.test.tsx
+++ b/frontend/src/app/pages/TypingPractice.test.tsx
@@ -143,4 +143,37 @@ describe('TypingPractice', () => {
       expect(mockCreateNote).toHaveBeenCalledWith('1', 'My reflection');
     });
   });
+
+  it('completes verse without restart when saving note mid-typing in blank mode (issue #38)', async () => {
+    const user = userEvent.setup();
+    renderAtPractice('col1');
+
+    // Switch to blank mode
+    await user.click(screen.getByRole('radio', { name: /blank/i }));
+
+    // Type ~90% of verse (24 of 27 chars: "Look at the birds of the ")
+    const verseStart = 'Look at the birds of the ';
+    const verseEnd = 'air.';
+    const typingArea = screen.getByRole('textbox', { name: /type the verse/i });
+    await user.type(typingArea, verseStart);
+
+    // Open notes, add and save a note
+    await user.click(screen.getByRole('button', { name: /open notes/i }));
+    await user.type(screen.getByPlaceholderText(/Add a note/i), 'My reflection');
+    await user.click(screen.getByRole('button', { name: /^Save$/i }));
+
+    await vi.waitFor(() => {
+      expect(mockCreateNote).toHaveBeenCalledWith('1', 'My reflection');
+    });
+
+    // Focus verse input and type remaining characters
+    await user.click(typingArea);
+    await user.type(typingArea, verseEnd);
+
+    // Verse should complete (no restart) - recordPractice called, completion screen shown
+    await vi.waitFor(() => {
+      expect(mockRecordPractice).toHaveBeenCalledWith('1', expect.any(Boolean), expect.any(Boolean));
+    });
+    expect(await screen.findByText(/Practice Complete/i, {}, { timeout: 2000 })).toBeInTheDocument();
+  }, 5000);
 });

--- a/frontend/src/app/pages/TypingPractice.tsx
+++ b/frontend/src/app/pages/TypingPractice.tsx
@@ -34,8 +34,10 @@ export function TypingPractice() {
   const [editingContent, setEditingContent] = useState<Record<string, string>>({});
   const [savedAt, setSavedAt] = useState<number | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [syncForceKey, setSyncForceKey] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const noteInputRef = useRef<HTMLTextAreaElement>(null);
+  const isComposingRef = useRef(false);
 
   // Derive practiceVerses and currentVerse early so useEffects can reference them
   const practiceVerses = verseIdParam
@@ -68,6 +70,14 @@ export function TypingPractice() {
     const timer = setTimeout(() => inputRef.current?.focus(), 0);
     return () => clearTimeout(timer);
   }, [currentVerseIndex, verses.length]);
+
+  // Refocus verse input after we force re-sync (reject spurious event)
+  useEffect(() => {
+    if (syncForceKey > 0) {
+      const timer = setTimeout(() => inputRef.current?.focus(), 0);
+      return () => clearTimeout(timer);
+    }
+  }, [syncForceKey]);
 
   // Load notes when current verse changes
   useEffect(() => {
@@ -196,7 +206,23 @@ export function TypingPractice() {
   const targetText = currentVerse?.text || '';
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newText = normalizeForCompare(e.target.value);
+    const rawValue = e.target.value;
+    const newText = normalizeForCompare(rawValue);
+
+    // Reject spurious onChange: value must be valid edit (append or delete at end only).
+    const isValidEdit =
+      newText === typedText ||
+      typedText.startsWith(newText) ||
+      newText.startsWith(typedText);
+
+    if (!isValidEdit) {
+      setSyncForceKey((k) => k + 1);
+      return;
+    }
+
+    if (isComposingRef.current) {
+      return;
+    }
 
     if (!startTime && newText.length === 1) {
       setStartTime(Date.now());
@@ -455,9 +481,21 @@ export function TypingPractice() {
                 ))}
                 <input
                   ref={inputRef}
+                  key={syncForceKey}
                   type="text"
                   value={typedText}
                   onChange={handleInputChange}
+                  onCompositionStart={() => { isComposingRef.current = true; }}
+                  onCompositionEnd={(e: React.CompositionEvent<HTMLInputElement>) => {
+                    isComposingRef.current = false;
+                    const finalText = normalizeForCompare((e.target as HTMLInputElement).value);
+                    if (finalText.length <= targetText.length) {
+                      setTypedText(finalText);
+                    }
+                  }}
+                  onBlur={() => {
+                    isComposingRef.current = false;
+                  }}
                   onKeyDown={(e) => {
                     if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Backspace'].includes(e.key)) {
                       e.preventDefault();


### PR DESCRIPTION
## Summary
Fixes #38 - Resolves two related bugs:
1. **Verse restart on note save** - Saving a note while typing a verse in blank mode no longer forces an unjustified restart when the user has >90% correct.
2. **Correct chars turning incorrect** - Switching to the note input and back no longer causes previously correct characters to turn red.

## Root cause
- When focusing the verse input after switching from the note panel, browsers fire a spurious `onChange` event with a corrupted value.
- This was overwriting `typedText` and causing both the restart behavior and the incorrect-character display.

## Changes
- **DataContext**: Wrap `getVersesByCollection` in `useCallback` to prevent unnecessary effect runs.
- **TypingPractice**: Validate `onChange` - only accept edits that are append or delete at end (reject spurious focus-triggered events).
- **On reject**: Force React re-sync via `syncForceKey` + input remount instead of direct DOM mutation (avoids cascading input events).
- **IME handling**: Add `onCompositionStart`/`onCompositionEnd` for robustness with input method editors.
- **Regression test**: Add test for note-save-during-typing in blank mode.

## Testing
- All 46 unit tests pass.
- Manually verified: typing → switch to note → save → switch back → type continues correctly.