### PR TITLE
Nested collections (closes #42)

### DIFF
--- a/backend/src/main/java/org/biblememory/controller/CollectionController.java
+++ b/backend/src/main/java/org/biblememory/controller/CollectionController.java
@@ -39,7 +39,8 @@ public class CollectionController {
         if (userId == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
-        Collection collection = collectionService.create(request.profileId(), userId, request.name());
+        Collection collection = collectionService.create(
+                request.profileId(), userId, request.name(), request.parentCollectionId());
         if (collection == null) {
             return ResponseEntity.notFound().build();
         }
@@ -61,6 +62,7 @@ public class CollectionController {
     }
 
     private CollectionDto toDto(Collection c) {
-        return new CollectionDto(c.getId(), c.getName(), c.getCreatedAt());
+        Long parentId = c.getParent() != null ? c.getParent().getId() : null;
+        return new CollectionDto(c.getId(), c.getName(), c.getCreatedAt(), parentId);
     }
 }

--- a/backend/src/main/java/org/biblememory/controller/PracticeController.java
+++ b/backend/src/main/java/org/biblememory/controller/PracticeController.java
@@ -4,20 +4,25 @@ import jakarta.validation.Valid;
 import org.biblememory.controller.dto.DueVerseDto;
 import org.biblememory.controller.dto.PracticeResultRequest;
 import org.biblememory.model.Verse;
+import org.biblememory.service.CollectionService;
 import org.biblememory.service.SpacedRepetitionService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/practice")
 public class PracticeController {
 
     private final SpacedRepetitionService spacedRepetitionService;
+    private final CollectionService collectionService;
 
-    public PracticeController(SpacedRepetitionService spacedRepetitionService) {
+    public PracticeController(SpacedRepetitionService spacedRepetitionService,
+                              CollectionService collectionService) {
         this.spacedRepetitionService = spacedRepetitionService;
+        this.collectionService = collectionService;
     }
 
     @PostMapping("/result")
@@ -43,8 +48,17 @@ public class PracticeController {
             return ResponseEntity.status(401).build();
         }
         List<Verse> due = spacedRepetitionService.getVersesDueForReview(userId);
+        final Set<Long> allowedCollectionIds;
+        if (collectionId == null) {
+            allowedCollectionIds = null;
+        } else {
+            allowedCollectionIds = collectionService.getSubtreeCollectionIdsIncludingRoot(collectionId, userId);
+            if (allowedCollectionIds.isEmpty()) {
+                return ResponseEntity.ok(List.of());
+            }
+        }
         List<DueVerseDto> dtos = due.stream()
-                .filter(v -> collectionId == null || v.getCollection().getId().equals(collectionId))
+                .filter(v -> allowedCollectionIds == null || allowedCollectionIds.contains(v.getCollection().getId()))
                 .map(v -> new DueVerseDto(v.getId(), v.getCollection().getId(), v.getReference(), v.getText(), v.getOrderIndex(), v.getSource(), v.getCreatedAt()))
                 .toList();
         return ResponseEntity.ok(dtos);

--- a/backend/src/main/java/org/biblememory/controller/dto/CollectionDto.java
+++ b/backend/src/main/java/org/biblememory/controller/dto/CollectionDto.java
@@ -2,4 +2,4 @@ package org.biblememory.controller.dto;
 
 import java.time.Instant;
 
-public record CollectionDto(Long id, String name, Instant createdAt) {}
+public record CollectionDto(Long id, String name, Instant createdAt, Long parentCollectionId) {}

--- a/backend/src/main/java/org/biblememory/controller/dto/CreateCollectionRequest.java
+++ b/backend/src/main/java/org/biblememory/controller/dto/CreateCollectionRequest.java
@@ -7,5 +7,6 @@ public record CreateCollectionRequest(
         @NotNull(message = "Profile ID is required")
         Long profileId,
         @NotBlank(message = "Name is required")
-        String name
+        String name,
+        Long parentCollectionId
 ) {}

--- a/backend/src/main/java/org/biblememory/model/Collection.java
+++ b/backend/src/main/java/org/biblememory/model/Collection.java
@@ -23,6 +23,14 @@ public class Collection {
     @Column(nullable = false, name = "created_at")
     private Instant createdAt;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_collection_id")
+    private Collection parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("createdAt ASC")
+    private List<Collection> children = new ArrayList<>();
+
     @OneToMany(mappedBy = "collection", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("orderIndex ASC")
     private List<Verse> verses = new ArrayList<>();
@@ -70,5 +78,21 @@ public class Collection {
 
     public void setVerses(List<Verse> verses) {
         this.verses = verses;
+    }
+
+    public Collection getParent() {
+        return parent;
+    }
+
+    public void setParent(Collection parent) {
+        this.parent = parent;
+    }
+
+    public List<Collection> getChildren() {
+        return children;
+    }
+
+    public void setChildren(List<Collection> children) {
+        this.children = children;
     }
 }

--- a/backend/src/main/java/org/biblememory/repository/CollectionRepository.java
+++ b/backend/src/main/java/org/biblememory/repository/CollectionRepository.java
@@ -1,13 +1,17 @@
 package org.biblememory.repository;
 
 import org.biblememory.model.Collection;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface CollectionRepository extends JpaRepository<Collection, Long> {
 
+    @EntityGraph(attributePaths = {"parent"})
     List<Collection> findByProfile_IdOrderByCreatedAtAsc(Long profileId);
+
+    List<Collection> findByParent_Id(Long parentId);
 
     boolean existsByIdAndProfile_UserId(Long id, Long userId);
 }

--- a/backend/src/main/java/org/biblememory/service/CollectionService.java
+++ b/backend/src/main/java/org/biblememory/service/CollectionService.java
@@ -6,7 +6,14 @@ import org.biblememory.repository.CollectionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Service
 public class CollectionService {
@@ -34,8 +41,43 @@ public class CollectionService {
                 .orElse(null);
     }
 
+    /**
+     * All collection IDs in the subtree rooted at {@code collectionId}, including the root.
+     * Empty if the collection does not exist or is not owned by {@code userId}.
+     */
+    @Transactional(readOnly = true)
+    public Set<Long> getSubtreeCollectionIdsIncludingRoot(Long collectionId, Long userId) {
+        Collection root = findByIdAndUserId(collectionId, userId);
+        if (root == null) {
+            return Set.of();
+        }
+        Long profileId = root.getProfile().getId();
+        List<Collection> all = collectionRepository.findByProfile_IdOrderByCreatedAtAsc(profileId);
+        Map<Long, List<Long>> childrenByParent = new HashMap<>();
+        for (Collection c : all) {
+            if (c.getParent() != null) {
+                childrenByParent
+                        .computeIfAbsent(c.getParent().getId(), k -> new ArrayList<>())
+                        .add(c.getId());
+            }
+        }
+        Set<Long> out = new HashSet<>();
+        Deque<Long> dq = new ArrayDeque<>();
+        dq.add(collectionId);
+        while (!dq.isEmpty()) {
+            Long id = dq.removeFirst();
+            if (!out.add(id)) {
+                continue;
+            }
+            for (Long childId : childrenByParent.getOrDefault(id, List.of())) {
+                dq.add(childId);
+            }
+        }
+        return out;
+    }
+
     @Transactional
-    public Collection create(Long profileId, Long userId, String name) {
+    public Collection create(Long profileId, Long userId, String name, Long parentCollectionId) {
         Profile profile = profileService.findByIdAndUserId(profileId, userId);
         if (profile == null) {
             return null;
@@ -43,6 +85,16 @@ public class CollectionService {
         Collection collection = new Collection();
         collection.setProfile(profile);
         collection.setName(name);
+        if (parentCollectionId != null) {
+            Collection parent = findByIdAndUserId(parentCollectionId, userId);
+            if (parent == null) {
+                return null;
+            }
+            if (!parent.getProfile().getId().equals(profileId)) {
+                return null;
+            }
+            collection.setParent(parent);
+        }
         return collectionRepository.save(collection);
     }
 

--- a/backend/src/test/java/org/biblememory/controller/CollectionControllerTest.java
+++ b/backend/src/test/java/org/biblememory/controller/CollectionControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.Instant;
 import java.util.List;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,6 +41,10 @@ class CollectionControllerTest {
     private JwtService jwtService;
 
     private static Collection createCollection(Long id, Long profileId, String name) {
+        return createCollection(id, profileId, name, null);
+    }
+
+    private static Collection createCollection(Long id, Long profileId, String name, Collection parent) {
         Profile profile = new Profile();
         profile.setId(profileId);
         profile.setUserId(1L);
@@ -48,6 +53,7 @@ class CollectionControllerTest {
         c.setProfile(profile);
         c.setName(name);
         c.setCreatedAt(Instant.now());
+        c.setParent(parent);
         return c;
     }
 
@@ -60,7 +66,8 @@ class CollectionControllerTest {
         mockMvc.perform(get("/api/collections").param("profileId", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1))
-                .andExpect(jsonPath("$[0].name").value("My Collection"));
+                .andExpect(jsonPath("$[0].name").value("My Collection"))
+                .andExpect(jsonPath("$[0].parentCollectionId").value(nullValue()));
 
         verify(collectionService).findByProfileId(1L, 1L);
     }
@@ -75,16 +82,17 @@ class CollectionControllerTest {
     @WithUserId
     void create_returns201WhenAuthenticated() throws Exception {
         Collection col = createCollection(1L, 1L, "New Collection");
-        when(collectionService.create(1L, 1L, "New Collection")).thenReturn(col);
+        when(collectionService.create(1L, 1L, "New Collection", null)).thenReturn(col);
 
         mockMvc.perform(post("/api/collections")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"profileId\":1,\"name\":\"New Collection\"}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(1))
-                .andExpect(jsonPath("$.name").value("New Collection"));
+                .andExpect(jsonPath("$.name").value("New Collection"))
+                .andExpect(jsonPath("$.parentCollectionId").value(nullValue()));
 
-        verify(collectionService).create(1L, 1L, "New Collection");
+        verify(collectionService).create(1L, 1L, "New Collection", null);
     }
 
     @Test
@@ -98,7 +106,7 @@ class CollectionControllerTest {
     @Test
     @WithUserId
     void create_returns404WhenProfileNotFound() throws Exception {
-        when(collectionService.create(999L, 1L, "Collection")).thenReturn(null);
+        when(collectionService.create(999L, 1L, "Collection", null)).thenReturn(null);
 
         mockMvc.perform(post("/api/collections")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -113,6 +121,34 @@ class CollectionControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"profileId\":1,\"name\":\"\"}"))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithUserId
+    void create_returns201WithParentWhenNested() throws Exception {
+        Collection parent = createCollection(5L, 1L, "Parent");
+        Collection child = createCollection(2L, 1L, "Child", parent);
+        when(collectionService.create(1L, 1L, "Child", 5L)).thenReturn(child);
+
+        mockMvc.perform(post("/api/collections")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"profileId\":1,\"name\":\"Child\",\"parentCollectionId\":5}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(2))
+                .andExpect(jsonPath("$.parentCollectionId").value(5));
+
+        verify(collectionService).create(1L, 1L, "Child", 5L);
+    }
+
+    @Test
+    @WithUserId
+    void create_returns404WhenParentInvalid() throws Exception {
+        when(collectionService.create(1L, 1L, "Child", 99L)).thenReturn(null);
+
+        mockMvc.perform(post("/api/collections")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"profileId\":1,\"name\":\"Child\",\"parentCollectionId\":99}"))
+                .andExpect(status().isNotFound());
     }
 
     @Test

--- a/backend/src/test/java/org/biblememory/controller/PracticeControllerTest.java
+++ b/backend/src/test/java/org/biblememory/controller/PracticeControllerTest.java
@@ -3,6 +3,7 @@ package org.biblememory.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.biblememory.security.JwtService;
 import org.biblememory.security.WithUserId;
+import org.biblememory.service.CollectionService;
 import org.biblememory.service.SpacedRepetitionService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,9 +16,11 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -36,6 +39,9 @@ class PracticeControllerTest {
 
     @MockBean
     private SpacedRepetitionService spacedRepetitionService;
+
+    @MockBean
+    private CollectionService collectionService;
 
     @MockBean
     private JwtService jwtService;
@@ -157,6 +163,7 @@ class PracticeControllerTest {
     @Test
     @WithUserId
     void getDueVerses_returns200WithCollectionFilter() throws Exception {
+        when(collectionService.getSubtreeCollectionIdsIncludingRoot(5L, 1L)).thenReturn(Set.of(5L, 7L));
         mockMvc.perform(get("/api/practice/due").param("collectionId", "5"))
                 .andExpect(status().isOk());
     }

--- a/frontend/src/app/context/DataContext.tsx
+++ b/frontend/src/app/context/DataContext.tsx
@@ -13,6 +13,8 @@ export interface Collection {
   id: string;
   name: string;
   profileId: string;
+  /** null = top-level collection */
+  parentCollectionId: string | null;
 }
 
 export interface Verse {
@@ -40,9 +42,11 @@ interface DataContextType {
   selectProfile: (profileId: string) => void;
   deleteProfile: (profileId: string) => Promise<void>;
   collections: Collection[];
-  createCollection: (name: string) => Promise<void>;
+  createCollection: (name: string, parentCollectionId?: string | null) => Promise<void>;
   deleteCollection: (collectionId: string) => Promise<void>;
   getVersesByCollection: (collectionId: string) => Verse[];
+  /** Verses in this collection and all nested sub-collections (for practice). */
+  getVersesByCollectionSubtree: (collectionId: string) => Verse[];
   addVerse: (collectionId: string, reference: string, text: string, source?: string) => Promise<void>;
   addBulkVerses: (collectionId: string, range: string) => Promise<{ added: number; skipped: number }>;
   deleteVerse: (verseId: string) => Promise<void>;
@@ -67,6 +71,7 @@ interface CollectionDto {
   id: number;
   name: string;
   createdAt: string;
+  parentCollectionId: number | null;
 }
 
 interface VerseDto {
@@ -111,7 +116,31 @@ function toCollection(dto: CollectionDto, profileId: string): Collection {
     id: String(dto.id),
     name: dto.name,
     profileId,
+    parentCollectionId:
+      dto.parentCollectionId != null ? String(dto.parentCollectionId) : null,
   };
+}
+
+/** All collection IDs in the subtree rooted at `rootId`, including `rootId`. */
+export function collectDescendantCollectionIds(
+  rootId: string,
+  collections: Collection[]
+): Set<string> {
+  const byParent = new Map<string | null, string[]>();
+  for (const c of collections) {
+    const p = c.parentCollectionId ?? null;
+    if (!byParent.has(p)) byParent.set(p, []);
+    byParent.get(p)!.push(c.id);
+  }
+  const out = new Set<string>();
+  const stack = [rootId];
+  while (stack.length) {
+    const id = stack.pop()!;
+    if (out.has(id)) continue;
+    out.add(id);
+    for (const child of byParent.get(id) ?? []) stack.push(child);
+  }
+  return out;
 }
 
 function toVerse(dto: VerseDto, collectionId: string): Verse {
@@ -267,21 +296,33 @@ export function DataProvider({ children }: { children: ReactNode }) {
     }
   };
 
-  const createCollection = async (name: string) => {
+  const createCollection = async (name: string, parentCollectionId?: string | null) => {
     if (!user || !currentProfile) return;
-    const dto = await api.post<CollectionDto>('/api/collections', {
+    const body: {
+      profileId: number;
+      name: string;
+      parentCollectionId?: number;
+    } = {
       profileId: Number(currentProfile.id),
       name,
-    });
+    };
+    if (parentCollectionId != null && parentCollectionId !== '') {
+      body.parentCollectionId = Number(parentCollectionId);
+    }
+    const dto = await api.post<CollectionDto>('/api/collections', body);
     const newCollection = toCollection(dto, currentProfile.id);
     setCollections((prev) => [...prev, newCollection]);
   };
 
   const deleteCollection = async (collectionId: string) => {
     if (!user) return;
+    const removedIds = collectDescendantCollectionIds(collectionId, collections);
     await api.delete(`/api/collections/${collectionId}`);
-    setCollections((prev) => prev.filter((c) => c.id !== collectionId));
-    setVerses((prev) => prev.filter((v) => v.collectionId !== collectionId));
+    setCollections((prev) => prev.filter((c) => !removedIds.has(c.id)));
+    setVerses((prev) => prev.filter((v) => !removedIds.has(v.collectionId)));
+    loadDueVerses().catch(() => {
+      // keep local state consistent with server
+    });
   };
 
   const getVersesByCollection = useCallback((collectionId: string): Verse[] => {
@@ -289,6 +330,21 @@ export function DataProvider({ children }: { children: ReactNode }) {
       .filter((v) => v.collectionId === collectionId)
       .sort((a, b) => a.order - b.order);
   }, [verses]);
+
+  const getVersesByCollectionSubtree = useCallback(
+    (collectionId: string): Verse[] => {
+      const ids = collectDescendantCollectionIds(collectionId, collections);
+      return verses
+        .filter((v) => ids.has(v.collectionId))
+        .sort((a, b) => {
+          if (a.collectionId !== b.collectionId) {
+            return a.collectionId.localeCompare(b.collectionId);
+          }
+          return a.order - b.order;
+        });
+    },
+    [collections, verses]
+  );
 
   const addVerse = async (collectionId: string, reference: string, text: string, source?: string) => {
     if (!user) return;
@@ -336,9 +392,13 @@ export function DataProvider({ children }: { children: ReactNode }) {
     });
   };
 
-  const getDueVerses = (collectionId: string): number => {
-    return dueVerses.filter((v) => String(v.collectionId) === collectionId).length;
-  };
+  const getDueVerses = useCallback(
+    (collectionId: string): number => {
+      const ids = collectDescendantCollectionIds(collectionId, collections);
+      return dueVerses.filter((v) => ids.has(String(v.collectionId))).length;
+    },
+    [collections, dueVerses]
+  );
 
   const getNotes = useCallback(async (verseId: string): Promise<Note[]> => {
     if (!user) return [];
@@ -401,6 +461,7 @@ export function DataProvider({ children }: { children: ReactNode }) {
         createCollection,
         deleteCollection,
         getVersesByCollection,
+        getVersesByCollectionSubtree,
         addVerse,
         addBulkVerses,
         deleteVerse,

--- a/frontend/src/app/pages/CollectionDetail.test.tsx
+++ b/frontend/src/app/pages/CollectionDetail.test.tsx
@@ -7,7 +7,10 @@ import { CollectionDetail } from './CollectionDetail';
 const mockAddVerse = vi.fn().mockResolvedValue(undefined);
 const mockAddBulkVerses = vi.fn().mockResolvedValue({ added: 2, skipped: 0 });
 const mockDeleteVerse = vi.fn().mockResolvedValue(undefined);
+const mockCreateCollection = vi.fn().mockResolvedValue(undefined);
 const mockGetVersesByCollection = vi.fn();
+const mockGetVersesByCollectionSubtree = vi.fn();
+const mockGetDueVerses = vi.fn(() => 0);
 const mockUseData = vi.fn();
 
 vi.mock('../context/DataContext', () => ({
@@ -45,19 +48,26 @@ describe('CollectionDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseData.mockReturnValue({
-      collections: [{ id: 'c1', name: 'Romans 8', profileId: '1' }],
+      collections: [{ id: 'c1', name: 'Romans 8', profileId: '1', parentCollectionId: null }],
       getVersesByCollection: mockGetVersesByCollection,
+      getVersesByCollectionSubtree: mockGetVersesByCollectionSubtree,
+      getDueVerses: mockGetDueVerses,
+      createCollection: mockCreateCollection,
       addVerse: mockAddVerse,
       addBulkVerses: mockAddBulkVerses,
       deleteVerse: mockDeleteVerse,
     });
     mockGetVersesByCollection.mockReturnValue([]);
+    mockGetVersesByCollectionSubtree.mockReturnValue([]);
   });
 
   it('shows Collection not found when collectionId is invalid', () => {
     mockUseData.mockReturnValue({
-      collections: [{ id: 'c1', name: 'Romans 8', profileId: '1' }],
+      collections: [{ id: 'c1', name: 'Romans 8', profileId: '1', parentCollectionId: null }],
       getVersesByCollection: vi.fn(),
+      getVersesByCollectionSubtree: vi.fn(() => []),
+      getDueVerses: vi.fn(() => 0),
+      createCollection: vi.fn(),
       addVerse: vi.fn(),
       addBulkVerses: vi.fn(),
       deleteVerse: vi.fn(),
@@ -70,6 +80,9 @@ describe('CollectionDetail', () => {
 
   it('renders verses and add verse UI when collection exists', () => {
     mockGetVersesByCollection.mockReturnValue([
+      { id: 'v1', reference: 'Romans 8:1', text: 'There is therefore now no condemnation.' },
+    ]);
+    mockGetVersesByCollectionSubtree.mockReturnValue([
       { id: 'v1', reference: 'Romans 8:1', text: 'There is therefore now no condemnation.' },
     ]);
     renderCollectionDetail('c1');
@@ -108,6 +121,9 @@ describe('CollectionDetail', () => {
     mockGetVersesByCollection.mockReturnValue([
       { id: 'v1', reference: 'Romans 8:1', text: 'There is therefore now no condemnation.' },
     ]);
+    mockGetVersesByCollectionSubtree.mockReturnValue([
+      { id: 'v1', reference: 'Romans 8:1', text: 'There is therefore now no condemnation.' },
+    ]);
     const user = userEvent.setup();
     renderCollectionDetail('c1');
 
@@ -120,5 +136,18 @@ describe('CollectionDetail', () => {
     await user.click(screen.getByRole('button', { name: /^delete$/i }));
 
     expect(mockDeleteVerse).toHaveBeenCalledWith('v1');
+  });
+
+  it('calls createCollection with parent when adding a sub-collection', async () => {
+    const user = userEvent.setup();
+    renderCollectionDetail('c1');
+
+    await user.type(
+      screen.getByPlaceholderText(/new sub-collection name/i),
+      'Chapter 1'
+    );
+    await user.click(screen.getByRole('button', { name: /^add$/i }));
+
+    expect(mockCreateCollection).toHaveBeenCalledWith('Chapter 1', 'c1');
   });
 });

--- a/frontend/src/app/pages/CollectionDetail.tsx
+++ b/frontend/src/app/pages/CollectionDetail.tsx
@@ -20,9 +20,19 @@ const VERSE_NUMBERS = Array.from({ length: 176 }, (_, i) => i + 1);
 export function CollectionDetail() {
   const { collectionId } = useParams<{ collectionId: string }>();
   const navigate = useNavigate();
-  const { collections, getVersesByCollection, addVerse, addBulkVerses, deleteVerse } = useData();
+  const {
+    collections,
+    getVersesByCollection,
+    getVersesByCollectionSubtree,
+    getDueVerses,
+    createCollection,
+    addVerse,
+    addBulkVerses,
+    deleteVerse,
+  } = useData();
 
   const [activeAddTab, setActiveAddTab] = useState('manual');
+  const [newSubCollectionName, setNewSubCollectionName] = useState('');
   const [manualReference, setManualReference] = useState('');
   const [manualText, setManualText] = useState('');
   const [esvBook, setEsvBook] = useState('John');
@@ -33,8 +43,30 @@ export function CollectionDetail() {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [verseToDelete, setVerseToDelete] = useState<string | null>(null);
 
-  const collection = collectionId ? collections.find(c => c.id === collectionId) : null;
+  const collection = collectionId ? collections.find((c) => c.id === collectionId) : null;
   const verses = collectionId ? getVersesByCollection(collectionId) : [];
+  const subtreeVerses = collectionId ? getVersesByCollectionSubtree(collectionId) : [];
+  const parentCollection =
+    collection?.parentCollectionId != null
+      ? collections.find((c) => c.id === collection.parentCollectionId) ?? null
+      : null;
+  const childCollections = collectionId
+    ? collections.filter((c) => c.parentCollectionId === collectionId)
+    : [];
+
+  const handleCreateSubCollection = async () => {
+    if (!collectionId || !newSubCollectionName.trim()) {
+      toast.error('Please enter a sub-collection name');
+      return;
+    }
+    try {
+      await createCollection(newSubCollectionName.trim(), collectionId);
+      setNewSubCollectionName('');
+      toast.success('Sub-collection created');
+    } catch (e) {
+      toast.error('Failed to create sub-collection');
+    }
+  };
 
   if (!collectionId || !collection) {
     return (
@@ -132,25 +164,114 @@ export function CollectionDetail() {
         {/* Header: mobile = back row, then title+play row (play right); desktop = back | title left, play right */}
         <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-2">
           <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
-            <Button variant="ghost" size="sm" onClick={() => navigate('/collections')} className="order-1 sm:order-1 self-start">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                parentCollection
+                  ? navigate(`/collections/${parentCollection.id}`)
+                  : navigate('/collections')
+              }
+              className="order-1 sm:order-1 self-start"
+            >
               <ArrowLeft className="h-4 w-4 mr-2" />
-              Back
+              {parentCollection ? parentCollection.name : 'Collections'}
             </Button>
-            <div className="flex items-center justify-between w-full gap-4 order-2 sm:order-2">
-              <h1 className="text-lg sm:text-xl font-bold">{collection.name}</h1>
-              {verses.length > 0 && (
-                <Button size="icon" className="sm:hidden shrink-0" onClick={() => navigate(`/collections/${collectionId}/practice`)} title="Typing">
-                  <Play className="h-4 w-4" />
-                </Button>
+            <div className="flex flex-col gap-0.5 order-2 sm:order-2 w-full">
+              {parentCollection && (
+                <div className="text-xs text-muted-foreground">
+                  <button
+                    type="button"
+                    className="hover:underline"
+                    onClick={() => navigate('/collections')}
+                  >
+                    Collections
+                  </button>
+                  <span aria-hidden="true"> / </span>
+                  <button
+                    type="button"
+                    className="hover:underline"
+                    onClick={() => navigate(`/collections/${parentCollection.id}`)}
+                  >
+                    {parentCollection.name}
+                  </button>
+                  <span aria-hidden="true"> / </span>
+                  <span className="text-foreground font-medium">{collection.name}</span>
+                </div>
               )}
+              <div className="flex items-center justify-between w-full gap-4">
+                <h1 className="text-lg sm:text-xl font-bold">{collection.name}</h1>
+                {subtreeVerses.length > 0 && (
+                  <Button
+                    size="icon"
+                    className="sm:hidden shrink-0"
+                    onClick={() => navigate(`/collections/${collectionId}/practice`)}
+                    title="Typing"
+                  >
+                    <Play className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
             </div>
           </div>
-          {verses.length > 0 && (
-            <Button size="icon" className="max-sm:hidden shrink-0" onClick={() => navigate(`/collections/${collectionId}/practice`)} title="Typing">
+          {subtreeVerses.length > 0 && (
+            <Button
+              size="icon"
+              className="max-sm:hidden shrink-0"
+              onClick={() => navigate(`/collections/${collectionId}/practice`)}
+              title="Typing"
+            >
               <Play className="h-4 w-4" />
             </Button>
           )}
         </div>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Sub-collections</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-col sm:flex-row gap-2">
+              <Input
+                placeholder="New sub-collection name (e.g. Chapter 1)"
+                value={newSubCollectionName}
+                onChange={(e) => setNewSubCollectionName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleCreateSubCollection();
+                }}
+              />
+              <Button type="button" onClick={handleCreateSubCollection}>
+                <Plus className="h-4 w-4 mr-2" />
+                Add
+              </Button>
+            </div>
+            {childCollections.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No sub-collections yet.</p>
+            ) : (
+              <ul className="space-y-2">
+                {childCollections.map((child) => {
+                  const due = getDueVerses(child.id);
+                  return (
+                    <li key={child.id}>
+                      <button
+                        type="button"
+                        onClick={() => navigate(`/collections/${child.id}`)}
+                        className="w-full flex items-center justify-between p-3 border rounded-lg hover:bg-muted text-left transition-colors"
+                      >
+                        <span className="font-medium text-sm sm:text-base">{child.name}</span>
+                        {due > 0 && (
+                          <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+                            {due} due
+                          </span>
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
 
         {/* Two-column layout on desktop: Add Verses (left) | Verses list (right) */}
         <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-8">

--- a/frontend/src/app/pages/Collections.test.tsx
+++ b/frontend/src/app/pages/Collections.test.tsx
@@ -54,8 +54,8 @@ describe('Collections', () => {
     mockUseData.mockReturnValue({
       currentProfile: { id: '1', name: 'Default' },
       collections: [
-        { id: 'c1', name: 'Romans 8', profileId: '1' },
-        { id: 'c2', name: 'Psalm 23', profileId: '1' },
+        { id: 'c1', name: 'Romans 8', profileId: '1', parentCollectionId: null },
+        { id: 'c2', name: 'Psalm 23', profileId: '1', parentCollectionId: null },
       ],
       createCollection: mockCreateCollection,
       deleteCollection: mockDeleteCollection,
@@ -78,11 +78,28 @@ describe('Collections', () => {
     expect(mockCreateCollection).toHaveBeenCalledWith('New Collection');
   });
 
+  it('lists only root collections, not nested ones', () => {
+    mockUseAuth.mockReturnValue({ user: { id: 'u1', username: 'test' } });
+    mockUseData.mockReturnValue({
+      currentProfile: { id: '1', name: 'Default' },
+      collections: [
+        { id: 'c1', name: 'Matthew', profileId: '1', parentCollectionId: null },
+        { id: 'c2', name: 'Chapter 1', profileId: '1', parentCollectionId: 'c1' },
+      ],
+      createCollection: mockCreateCollection,
+      deleteCollection: mockDeleteCollection,
+    });
+    renderCollections();
+
+    expect(screen.getByText('Matthew')).toBeInTheDocument();
+    expect(screen.queryByText('Chapter 1')).not.toBeInTheDocument();
+  });
+
   it('opens delete dialog and calls deleteCollection on confirm', async () => {
     mockUseAuth.mockReturnValue({ user: { id: 'u1', username: 'test' } });
     mockUseData.mockReturnValue({
       currentProfile: { id: '1', name: 'Default' },
-      collections: [{ id: 'c1', name: 'Romans 8', profileId: '1' }],
+      collections: [{ id: 'c1', name: 'Romans 8', profileId: '1', parentCollectionId: null }],
       createCollection: mockCreateCollection,
       deleteCollection: mockDeleteCollection,
     });
@@ -93,7 +110,7 @@ describe('Collections', () => {
     const buttons = within(row!).getAllByRole('button');
     await user.click(buttons[1]);
 
-    expect(screen.getByText(/are you sure you want to delete/i)).toBeInTheDocument();
+    expect(screen.getByText(/nested sub-collections/i)).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /^delete$/i }));
 
     expect(mockDeleteCollection).toHaveBeenCalledWith('c1');

--- a/frontend/src/app/pages/Collections.tsx
+++ b/frontend/src/app/pages/Collections.tsx
@@ -69,7 +69,7 @@ export function Collections() {
   };
 
   const currentCollections = collections.filter(
-    c => c.profileId === currentProfile?.id
+    (c) => c.profileId === currentProfile?.id && c.parentCollectionId == null
   );
 
   return (
@@ -80,7 +80,7 @@ export function Collections() {
           <CardHeader>
             <CardTitle className="text-base">My Collections</CardTitle>
             <CardDescription className="text-sm">
-              Create collections to group verses by topic or study plan
+              Create top-level collections here; open one to add sub-collections (e.g. chapters).
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -141,8 +141,8 @@ export function Collections() {
           <DialogHeader>
             <DialogTitle>Delete Collection</DialogTitle>
             <DialogDescription>
-              Are you sure you want to delete this collection? This will also delete
-              all verses in this collection. This action cannot be undone.
+              This removes this collection, any nested sub-collections, and all verses inside them.
+              This cannot be undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/frontend/src/app/pages/TypingPractice.test.tsx
+++ b/frontend/src/app/pages/TypingPractice.test.tsx
@@ -50,9 +50,9 @@ describe('TypingPractice', () => {
     vi.clearAllMocks();
     mockUseData.mockReturnValue({
       collections: [
-        { id: 'col1', name: 'Test Collection', profileId: '1' },
+        { id: 'col1', name: 'Test Collection', profileId: '1', parentCollectionId: null },
       ],
-      getVersesByCollection: (id: string) => (id === 'col1' ? [mockVerse] : []),
+      getVersesByCollectionSubtree: (id: string) => (id === 'col1' ? [mockVerse] : []),
       recordPractice: mockRecordPractice,
       getNotes: mockGetNotes,
       createNote: mockCreateNote,
@@ -64,7 +64,7 @@ describe('TypingPractice', () => {
   it('shows Collection not found when collectionId is invalid', () => {
     mockUseData.mockReturnValue({
       collections: [],
-      getVersesByCollection: () => [],
+      getVersesByCollectionSubtree: () => [],
       recordPractice: vi.fn(),
       getNotes: vi.fn(),
       createNote: vi.fn(),
@@ -78,8 +78,8 @@ describe('TypingPractice', () => {
 
   it('shows No verses when collection has no verses', () => {
     mockUseData.mockReturnValue({
-      collections: [{ id: 'col1', name: 'Test', profileId: '1' }],
-      getVersesByCollection: () => [],
+      collections: [{ id: 'col1', name: 'Test', profileId: '1', parentCollectionId: null }],
+      getVersesByCollectionSubtree: () => [],
       recordPractice: vi.fn(),
       getNotes: vi.fn(),
       createNote: vi.fn(),

--- a/frontend/src/app/pages/TypingPractice.tsx
+++ b/frontend/src/app/pages/TypingPractice.tsx
@@ -18,7 +18,15 @@ export function TypingPractice() {
   const [searchParams] = useSearchParams();
   const verseIdParam = searchParams.get('verseId');
   const navigate = useNavigate();
-  const { collections, getVersesByCollection, recordPractice, getNotes, createNote, updateNote, deleteNote } = useData();
+  const {
+    collections,
+    getVersesByCollectionSubtree,
+    recordPractice,
+    getNotes,
+    createNote,
+    updateNote,
+    deleteNote,
+  } = useData();
 
   const [verses, setVerses] = useState<Verse[]>([]);
   const [currentVerseIndex, setCurrentVerseIndex] = useState(0);
@@ -58,9 +66,9 @@ export function TypingPractice() {
 
   useEffect(() => {
     if (collectionId) {
-      setVerses(getVersesByCollection(collectionId));
+      setVerses(getVersesByCollectionSubtree(collectionId));
     }
-  }, [collectionId, getVersesByCollection]);
+  }, [collectionId, getVersesByCollectionSubtree]);
 
   useEffect(() => {
     resetPractice();


### PR DESCRIPTION
## Summary
Implements [issue #42](https://github.com/JaredjWilliams/Bible-memory/issues/42): hierarchical collections (sub-collections), subtree-aware practice/due filtering, and UI for roots vs nested folders.

## Backend
- Optional `parent_collection_id` on `Collection` with `CascadeType.ALL` on children (delete parent removes subtree and verses).
- `CollectionDto` / create request include optional `parentCollectionId`; list returns all profile collections with parent ids.
- `GET /api/practice/due?collectionId=` filters by the collection subtree (not only the root id).

## Frontend
- `DataContext`: `parentCollectionId`, `createCollection(name, parentId?)`, subtree helpers, cascade-safe `deleteCollection` local state.
- Collections page: top-level collections only; copy updates for nested delete.
- Collection detail: breadcrumb/back, sub-collection list with due counts, create sub-collection.
- Typing practice: verses loaded for the full subtree.

## Testing
- Backend and frontend unit tests updated; run `mvn test` and `npm test`.